### PR TITLE
Limelight distance + adaptive flywheel speed

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Stanley/testingOpmodes/limelightFlywheelDistanceTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Stanley/testingOpmodes/limelightFlywheelDistanceTest.java
@@ -1,0 +1,33 @@
+package org.firstinspires.ftc.teamcode.Stanley.testingOpmodes;
+
+import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
+import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
+
+import org.firstinspires.ftc.teamcode.Stanley.finalizedClasses.outtakeV3;
+
+@TeleOp
+public class limelightFlywheelDistanceTest extends LinearOpMode {
+
+    @Override
+    public void runOpMode() throws InterruptedException {
+        outtakeV3 outtake = new outtakeV3(hardwareMap, "Red", true);
+        boolean autoSpeedEnabled = false;
+
+        waitForStart();
+
+        while (opModeIsActive()) {
+            if (gamepad1.yWasPressed()) autoSpeedEnabled = !autoSpeedEnabled;
+
+            double setpoint = autoSpeedEnabled ? outtake.updateFlywheelSpeedFromTagDistance() : 0.0;
+            if (!autoSpeedEnabled) outtake.spin_flywheel(0.0, 25);
+
+            telemetry.addData("Auto Speed", autoSpeedEnabled);
+            telemetry.addData("Has Target", outtake.apriltag != null && outtake.apriltag.hasValidTarget());
+            telemetry.addData("Distance M (last)", outtake.lastTagDistanceM);
+            telemetry.addData("Setpoint (tps)", setpoint);
+            telemetry.addData("FlywheelR Vel (tps)", outtake.flywheelDriveR.getVelocity());
+            telemetry.update();
+        }
+    }
+}
+

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Stanley/testingOpmodes/limelighttest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Stanley/testingOpmodes/limelighttest.java
@@ -21,6 +21,7 @@ public class limelighttest extends LinearOpMode {
             aprilTagOperator.scanOnce();
             telemetry.addData("tx", aprilTagOperator.getYaw());
             telemetry.addData("ty", aprilTagOperator.getPitch());
+            telemetry.addData("distanceM", aprilTagOperator.getDistance());
             telemetry.addData("Botpose", aprilTagOperator.getBotPose());
             telemetry.addData("Tag ID",aprilTagOperator.getTagId());
             telemetry.update();


### PR DESCRIPTION
Implements Limelight-based distance calculation and uses it to drive adaptive flywheel speed control.\n\nAlso includes a refactor to improve AprilTag distance calculation stability.